### PR TITLE
Updated a message

### DIFF
--- a/gyazowin.cpp
+++ b/gyazowin.cpp
@@ -947,7 +947,7 @@ BOOL uploadFile(HWND hwnd, LPCTSTR fileName)
 		}
 	} else {
 		// �A�b�v���[�h���s...
-		MessageBox(hwnd, _T("Failed to upload"), szTitle, MB_ICONERROR | MB_OK);
+		MessageBox(hwnd, _T("Failed to upload - Unkown Error (Check your internet speed)"), szTitle, MB_ICONERROR | MB_OK);
 	}
 
 	return FALSE;


### PR DESCRIPTION
After some debugging, me and @thecjgcjg realized that if you upload too big of a image your internet cant upload it fast enough. C++ has a 30 second time out on HTTP Requests, so this was the next best option.
